### PR TITLE
Update hit method so that when health is 0, the ship is sunk

### DIFF
--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -15,6 +15,7 @@ class Ship
 
   def hit
     @health -= 1
+    @sunk = true if @health == 0
   end
 
 end

--- a/test/ship_test.rb
+++ b/test/ship_test.rb
@@ -6,7 +6,6 @@ class ShipTest < Minitest::Test
 
   def setup
     @cruiser = Ship.new("Cruiser", 3)
-
   end
 
 
@@ -31,5 +30,9 @@ class ShipTest < Minitest::Test
     @cruiser.hit
     assert_equal 1, @cruiser.health
   end
-  
+
+  def test_reducing_health_to_0_sinks_the_ship
+    3.times { @cruiser.hit }
+    assert @cruiser.sunk?
+  end
 end


### PR DESCRIPTION
Co-authored-by: Daniel Moran <9169813+danmoran-pro@users.noreply.github.com>
Updated the hit method and tested that if you hit a ship enough times to reduce its health to 0, then the instance variable @sunk gets set to true.